### PR TITLE
Enhanced error parsing

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,10 +1,13 @@
 import DevourClient from 'devour-client';
 import models from '../models';
+import errorMiddleware from '../middlewares/errors';
 
 export default function createClient(apiUrl = 'localhost') {
   const client = new DevourClient({
     apiUrl,
   });
+
+  client.replaceMiddleware('errors', errorMiddleware);
 
   models.forEach(model => client.define(model.name, model.attributes));
   return client;

--- a/src/middlewares/errors.js
+++ b/src/middlewares/errors.js
@@ -1,0 +1,52 @@
+const errorKey = (index, error) => {
+  if (error.source) {
+    if (error.source.pointer) {
+      return error.source.pointer.split('/').pop();
+    }
+
+    if (error.source.parameter) {
+      return error.source.parameter;
+    }
+  }
+
+  return index;
+};
+
+const mapError = error => ({
+  id: error.id,
+  links: error.links,
+  status: error.status,
+  code: error.code,
+  title: error.title,
+  detail: error.detail,
+  meta: error.meta,
+});
+
+export default {
+  name: 'errors',
+  error(payload) {
+    if (payload.response) {
+      if (payload.response.data && payload.response.data.errors) {
+        const errors = {};
+
+        payload.response.data.errors.forEach((error, index) => {
+          errors[errorKey(index, error)] = mapError(error);
+        });
+
+        return errors;
+      }
+
+      return {
+        data: {
+          title: payload.response.statusText,
+        },
+      };
+    }
+
+    if (payload instanceof Error) {
+      return payload;
+    }
+
+    return null;
+  },
+};

--- a/src/middlewares/errors.spec.js
+++ b/src/middlewares/errors.spec.js
@@ -1,0 +1,140 @@
+import errorMiddleware from './errors';
+
+describe('error middleware', () => {
+  test('to set name correctly', () => {
+    expect(errorMiddleware.name).toBe('errors');
+  });
+
+  test('to return server error when no data', () => {
+    const errors = errorMiddleware.error({
+      response: {
+        statusText: 'Bad Request',
+      },
+    });
+
+    expect(errors).toEqual({
+      data: {
+        title: 'Bad Request',
+      },
+    });
+  });
+
+  test('to return full single error without source', () => {
+    const errors = errorMiddleware.error({
+      response: {
+        data: {
+          errors: [
+            {
+              id: '123',
+              links: {
+                about: 'https://joblocal.api-docs.io/',
+              },
+              status: '404',
+              code: '123',
+              title: 'Resource not found.',
+              detail: 'The resource could not be found during proessing. Please create it first',
+              meta: {
+                foo: 'bar',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(errors).toEqual({
+      0: {
+        id: '123',
+        links: {
+          about: 'https://joblocal.api-docs.io/',
+        },
+        status: '404',
+        code: '123',
+        title: 'Resource not found.',
+        detail: 'The resource could not be found during proessing. Please create it first',
+        meta: {
+          foo: 'bar',
+        },
+      },
+    });
+  });
+
+  test('to return multiple errors without source', () => {
+    const errors = errorMiddleware.error({
+      response: {
+        data: {
+          errors: [
+            {
+              title: 'Resource not found on earth.',
+            },
+            {
+              title: 'Resource not found on the moon.',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(errors).toEqual({
+      0: {
+        title: 'Resource not found on earth.',
+      },
+      1: {
+        title: 'Resource not found on the moon.',
+      },
+    });
+  });
+
+  test('to return error with source pointer', () => {
+    const errors = errorMiddleware.error({
+      response: {
+        data: {
+          errors: [
+            {
+              title: 'Age is not a number.',
+              source: {
+                pointer: '/data/attributes/age',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(errors).toEqual({
+      age: {
+        title: 'Age is not a number.',
+      },
+    });
+  });
+
+  test('to return error with source pointer', () => {
+    const errors = errorMiddleware.error({
+      response: {
+        data: {
+          errors: [
+            {
+              title: 'Page is not a positive number.',
+              source: {
+                parameter: 'page',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(errors).toEqual({
+      page: {
+        title: 'Page is not a positive number.',
+      },
+    });
+  });
+
+  test('to return error object correctly', () => {
+    const errorPassthrough = new Error();
+    const errors = errorMiddleware.error(errorPassthrough);
+
+    expect(errors).toBe(errorPassthrough);
+  });
+});


### PR DESCRIPTION
The default devourJS middleware only sets the title and detail properties on error objects. I would like to pass all of the available properties defined by the JSON:API spec along to the user of the client.

This would allow us to check for the status property in error objects (fix for the publication not found error).