### PR TITLE
Feature/id token function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joblocal/api-client",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "This repository provides an api-client to use the joblocal api.",
   "files": [
     "dist",

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ import createClient from '@joblocal/api-client';
 
 const client = createClient({
   url: 'https://api.joblocal.de/v4',
-  token: 'user_id_token' || null,
+  token: 'user_id_token' || () => 'id_token' || null,
 });
 ```
 

--- a/src/middlewares/tokenAuthentication.js
+++ b/src/middlewares/tokenAuthentication.js
@@ -3,13 +3,17 @@ export default ({ token = null } = {}) => ({
   req: (payload) => {
     if (token === null) return payload;
 
+    const bearer = `Bearer ${(typeof token === 'function'
+      ? token()
+      : token)}`;
+
     return Object.assign(payload, {
       req: {
         ...payload.req,
         headers: {
           ...payload.headers,
-          Authorization: `Bearer ${token}`,
-          TOKEN: `Bearer ${token}`,
+          Authorization: bearer,
+          TOKEN: bearer,
         },
       },
     });

--- a/src/middlewares/tokenAuthentication.spec.js
+++ b/src/middlewares/tokenAuthentication.spec.js
@@ -24,6 +24,13 @@ describe('token authentication middleware', () => {
     });
   });
 
+  test('to call token function if provided', () => {
+    const tokenFn = jest.fn();
+    tokenAuthenticationMiddleware({ token: tokenFn }).req(request);
+
+    expect(tokenFn).toHaveBeenCalled();
+  });
+
   test('to skip adding Authorization header', () => {
     const payload = tokenAuthenticationMiddleware().req(request);
     expect(payload).toEqual(request);


### PR DESCRIPTION
Sometimes the id_token is not available when creating the api client initially. It helps to be able to pass a function (returning the id_token) which is then called when the auth middleware is executed.